### PR TITLE
Feature valida gitcreaterelease

### DIFF
--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -54,7 +54,7 @@ def execute() {
 
       stage("Quality Gate"){
             timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
-                def qg = waitForQualityGate webhookSecretId: 'DevOps2020' // Reuse taskId previously collected by withSonarQubeEnv
+                def qg = waitForQualityGate webhookSecretId: 'devops2020' // Reuse taskId previously collected by withSonarQubeEnv
                 echo "Status: ${qg.status}"
                 if (qg.status != 'OK') {
                     throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -63,7 +63,7 @@ def execute() {
                 }
             }
         }catch (Exception e){
-            error e
+            error e.toString()
             allStagesPassed = false
         }
     }

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -95,7 +95,8 @@ def executeError(e) {
     error message
     //error para output del pipeline mas detallado
     //throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
-    echo e.toString()
+    echo "OUTPUT ERROR ${e.toString()}"
+    println("OUTPUT ERROR "+e.toString());
 }
 
 return this

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -53,13 +53,17 @@ def execute() {
     }
 
       stage("Quality Gate"){
+        try{
             timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
-                def qg = waitForQualityGate webhookSecretId: 'devops2020' // Reuse taskId previously collected by withSonarQubeEnv
+                def qg = waitForQualityGate // Reuse taskId previously collected by withSonarQubeEnv
                 echo "Status: ${qg.status}"
                 if (qg.status != 'OK') {
                     throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
                 }
             }
+        }catch (Exception e){
+            allStagesPassed = false
+        }
       }
 
 

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -90,13 +90,15 @@ def execute() {
 }
 
 def executeError(e) {
+    echo "OUTPUT ERROR ${e.toString()}"
+    println("OUTPUT ERROR "+e.toString());
+    
     //Error para slack
     def message = env.ERROR_MESSAGE == '' || env.ERROR_MESSAGE == null ? "[Stage ${env.JENKINS_STAGE}] Pipeline aborted due stage failure" : env.ERROR_MESSAGE 
     error message
     //error para output del pipeline mas detallado
     //throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
-    echo "OUTPUT ERROR ${e.toString()}"
-    println("OUTPUT ERROR "+e.toString());
+
 }
 
 return this

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -52,7 +52,8 @@ def execute() {
                 def qg = waitForQualityGate() // Reuse taskId previously collected by withSonarQubeEnv
                 echo "Status: ${qg.status}"
                 if (qg.status != 'OK') {
-                    throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
+                    env.ERROR_MESSAGE = "Pipeline aborted due to quality gate failure: ${qg.status}"
+                    error env.ERROR_MESSAGE
                 }
             }
         }catch (Exception e){

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -40,16 +40,27 @@ def execute() {
             withSonarQubeEnv(installationName: 'sonar-server') {
                 sh './mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar'
             }
-            timeout(time: 1, unit: 'HOURS') { // Just in case something goes wrong, pipeline will be killed after a timeout
-                def qg = waitForQualityGate webhookSecretId: 'DevOps2020' // Reuse taskId previously collected by withSonarQubeEnv
-                if (qg.status != 'OK') {
-                    throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
-                }
-            }
+            // timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
+            //     def qg = waitForQualityGate webhookSecretId: 'DevOps2020' // Reuse taskId previously collected by withSonarQubeEnv
+            //     echo "Status: ${qg.status}"
+            //     if (qg.status != 'OK') {
+            //         throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
+            //     }
+            // }
         }catch (Exception e){
             allStagesPassed = false
         }
     }
+
+      stage("Quality Gate"){
+            timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
+                def qg = waitForQualityGate webhookSecretId: 'DevOps2020' // Reuse taskId previously collected by withSonarQubeEnv
+                echo "Status: ${qg.status}"
+                if (qg.status != 'OK') {
+                    throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
+                }
+            }
+      }
 
 
     stage('nexusUpload') {

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -52,8 +52,9 @@ def execute() {
         }
     }
 
-      stage("Quality Gate"){
+    stage("Quality Gate"){
         try{
+            sleep(10)
             timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
                 def qg = waitForQualityGate // Reuse taskId previously collected by withSonarQubeEnv
                 echo "Status: ${qg.status}"
@@ -62,9 +63,10 @@ def execute() {
                 }
             }
         }catch (Exception e){
+            error e
             allStagesPassed = false
         }
-      }
+    }
 
 
     stage('nexusUpload') {

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -91,10 +91,11 @@ def execute() {
 
 def executeError(e) {
     //Error para slack
-    env.ERROR_MESSAGE = "Pipeline aborted due ${env.JENKINS_STAGE} stage failure"
-    error env.ERROR_MESSAGE
+    def message = env.ERROR_MESSAGE == '' || env.ERROR_MESSAGE == null ? "[Stage ${env.JENKINS_STAGE}] Pipeline aborted due stage failure" : env.ERROR_MESSAGE 
+    error message
     //error para output del pipeline mas detallado
-    throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
+    //throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
+    echo "${e.toString()}"
 }
 
 return this

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -8,7 +8,7 @@ def execute() {
         try{
             env.JENKINS_STAGE = env.STAGE_NAME
             echo env.JENKINS_STAGE
-            sh './mvnwkk clean compile -e'
+            sh './mvnw clean compile -e'
         }catch (Exception e){
             executeError(e)
         }
@@ -90,14 +90,11 @@ def execute() {
 }
 
 def executeError(e) {
+    //error para output del pipeline mas detallado
     echo "OUTPUT ERROR ${e.toString()}"
-    println("OUTPUT ERROR "+e.toString());
-    
-    //Error para slack
+    //Error para slack desde post actions en ejecucion.groovy
     def message = env.ERROR_MESSAGE == '' || env.ERROR_MESSAGE == null ? "[Stage ${env.JENKINS_STAGE}] Pipeline aborted due stage failure" : env.ERROR_MESSAGE 
     error message
-    //error para output del pipeline mas detallado
-    //throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
 
 }
 

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -8,7 +8,7 @@ def execute() {
         try{
             env.JENKINS_STAGE = env.STAGE_NAME
             echo env.JENKINS_STAGE
-            sh './mvnw clean compile -e'
+            sh './mvnwkk clean compile -e'
         }catch (Exception e){
             executeError(e)
         }

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -56,7 +56,7 @@ def execute() {
         try{
             sleep(10)
             timeout(time: 15, unit: 'MINUTES') { // Just in case something goes wrong, pipeline will be killed after a timeout
-                def qg = waitForQualityGate // Reuse taskId previously collected by withSonarQubeEnv
+                def qg = waitForQualityGate() // Reuse taskId previously collected by withSonarQubeEnv
                 echo "Status: ${qg.status}"
                 if (qg.status != 'OK') {
                     throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -41,7 +41,7 @@ def execute() {
                 sh './mvnw org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar'
             }
             timeout(time: 1, unit: 'HOURS') { // Just in case something goes wrong, pipeline will be killed after a timeout
-                def qg = waitForQualityGate() // Reuse taskId previously collected by withSonarQubeEnv
+                def qg = waitForQualityGate webhookSecretId: 'DevOps2020' // Reuse taskId previously collected by withSonarQubeEnv
                 if (qg.status != 'OK') {
                     throw new Exception("Pipeline aborted due to quality gate failure: ${qg.status}");
                 }

--- a/vars/mavenci.groovy
+++ b/vars/mavenci.groovy
@@ -95,7 +95,7 @@ def executeError(e) {
     error message
     //error para output del pipeline mas detallado
     //throw new Exception("${env.ERROR_MESSAGE} ${e.toString()}");
-    echo "${e.toString()}"
+    echo e.toString()
 }
 
 return this

--- a/vars/notification.groovy
+++ b/vars/notification.groovy
@@ -6,7 +6,7 @@ def failure() {
 }
 
 def failure(msg) {
-    def template = "Build Success: [devops-usach-grupo2][Proyecto ${env.BUILD_TOOL}]";
+    def template = "Build Failure: [devops-usach-grupo2][Proyecto ${env.BUILD_TOOL}]";
     slackSend color: "danger", message: "Build Failure: ${template} ${msg}", teamDomain: 'devops-usach-2020', tokenCredentialId: 'slack-credentials'
 }
 

--- a/vars/notification.groovy
+++ b/vars/notification.groovy
@@ -6,7 +6,8 @@ def failure() {
 }
 
 def failure(msg) {
-    slackSend color: "danger", message: "Build Failure: ${msg}", teamDomain: 'devops-usach-2020', tokenCredentialId: 'slack-credentials'
+    def template = "Build Success: [devops-usach-grupo2][Proyecto ${env.BUILD_TOOL}]";
+    slackSend color: "danger", message: "Build Failure: ${template} ${msg}", teamDomain: 'devops-usach-2020', tokenCredentialId: 'slack-credentials'
 }
 
 def success() {
@@ -15,5 +16,6 @@ def success() {
 }
 
 def success(msg) {
-    slackSend color: "good", message: "Build Success: ${msg}", teamDomain: 'devops-usach-2020', tokenCredentialId: 'slack-credentials'
+    def template = "Build Success: [devops-usach-grupo2][Proyecto ${env.BUILD_TOOL}]";
+    slackSend color: "good", message: "Build Success: ${template} ${msg}", teamDomain: 'devops-usach-2020', tokenCredentialId: 'slack-credentials'
 }


### PR DESCRIPTION
Se valida que el Stage gitCreateRelease solo se corra cuando todos los stages previos han sido exitosos.
Esto se puede hacer de varias formas, lo que hice fui agregar try/catch  más  la función error, con esto se logra enviar a las post actions creadas en ejecucion.groovy el mensaje personalizado o uno por defecto y esto luego es enviado a slack. También genera un echo para mostrar en el Output de jenkins más detalles sobre el error.

Agregué un stage Quality Gate que se encarga de revisar cual fue el resultado de la prueba con sonar. Esto se puede utililzar como 1 de los 2 puntos extras de validación que propone el laboratorio y además no me hacia sentido que si falla las pruebas en Sonar el pipeline siga corriendo y terminaria afectando al punto "correr solo gitCreateRelease cuando el resto haya sido exitoso"
<img width="599" alt="Captura de pantalla 2021-01-16 a la(s) 1 08 07 a  m" src="https://user-images.githubusercontent.com/73804495/104796820-5b19e000-5798-11eb-9bed-05d546e982cf.png">
![Captura de pantalla 2021-01-16 a la(s) 1 07 54 a  m](https://user-images.githubusercontent.com/73804495/104796822-5d7c3a00-5798-11eb-9577-3964cc752c80.png)
![Captura de pantalla 2021-01-16 a la(s) 1 06 17 a  m](https://user-images.githubusercontent.com/73804495/104796824-5f45fd80-5798-11eb-8957-e642369ae44a.png)


